### PR TITLE
Add base class with factory pattern for protocol versions

### DIFF
--- a/examples/tuya_kwh_meter.cpp
+++ b/examples/tuya_kwh_meter.cpp
@@ -22,7 +22,7 @@
 
 #define TUYA_COMMAND_PORT 6668
 
-#include "tuyaAPI33.hpp"
+#include "tuyaAPI.hpp"
 #include <unistd.h>
 #include <iostream>
 #include <sstream>
@@ -33,7 +33,7 @@
 #include <fstream>
 
 
-bool get_device_by_name(const std::string name, std::string &id, std::string &key, std::string &address)
+bool get_device_by_name(const std::string name, std::string &id, std::string &key, std::string &address, std::string &version)
 {
 	std::string szFileContent;
 	std::ifstream myfile (SECRETSFILE);
@@ -69,6 +69,7 @@ bool get_device_by_name(const std::string name, std::string &id, std::string &ke
 				id =  jDevices["devices"][i]["id"].asString();
 				key = jDevices["devices"][i]["key"].asString();
 				address = jDevices["devices"][i]["address"].asString();
+				version = jDevices["devices"][i]["version"].asString();
 				return true;
 			}
 		}
@@ -86,8 +87,8 @@ int main(int argc, char *argv[])
 	   exit(0);
 	}
 
-	std::string device_id, device_key, device_address;
-	if (!get_device_by_name(std::string(argv[1]), device_id, device_key, device_address))
+	std::string device_id, device_key, device_address, device_version;
+	if (!get_device_by_name(std::string(argv[1]), device_id, device_key, device_address, device_version))
 	{
 		std::cout << "Error: Device unknown\n";
 		exit(0);
@@ -98,12 +99,17 @@ int main(int argc, char *argv[])
 	std::cout << "  id : " << device_id << "\n";
 	std::cout << "  key : " << device_key<< "\n";
 	std::cout << "  address : " << device_address << "\n";
+	std::cout << "  version : " << device_version << "\n";
 #endif
 
 	unsigned char message_buffer[MAX_BUFFER_SIZE];
 
-	tuyaAPI33 *tuyaclient;
-	tuyaclient = new tuyaAPI33();
+	tuyaAPI *tuyaclient = tuyaAPI::create(device_version);
+	if (!tuyaclient)
+	{
+		std::cout << "Error: Unsupported protocol version " << device_version << "\n";
+		exit(0);
+	}
 
 	if (!tuyaclient->ConnectToDevice(device_address, TUYA_COMMAND_PORT))
 	{

--- a/examples/tuya_switch.cpp
+++ b/examples/tuya_switch.cpp
@@ -21,7 +21,7 @@
 
 #define TUYA_COMMAND_PORT 6668
 
-#include "tuyaAPI33.hpp"
+#include "tuyaAPI.hpp"
 #include <iostream>
 #include <sstream>
 #include <string.h>
@@ -37,7 +37,7 @@ void error(const char *msg)
 }
 
 
-bool get_device_by_name(const std::string name, std::string &id, std::string &key, std::string &address)
+bool get_device_by_name(const std::string name, std::string &id, std::string &key, std::string &address, std::string &version)
 {
 	std::string szFileContent;
 	std::ifstream myfile (SECRETSFILE);
@@ -74,6 +74,7 @@ bool get_device_by_name(const std::string name, std::string &id, std::string &ke
 				id =  jDevices["devices"][i]["id"].asString();
 				key = jDevices["devices"][i]["key"].asString();
 				address = jDevices["devices"][i]["address"].asString();
+				version = jDevices["devices"][i]["version"].asString();
 				return true;
 			}
 		}
@@ -92,8 +93,8 @@ int main(int argc, char *argv[])
 	   exit(0);
 	}
 
-	std::string device_id, device_key, device_address;
-	if (!get_device_by_name(std::string(argv[1]), device_id, device_key, device_address))
+	std::string device_id, device_key, device_address, device_version;
+	if (!get_device_by_name(std::string(argv[1]), device_id, device_key, device_address, device_version))
 	{
 		std::cout << "unkown device\n";
 		exit(0);
@@ -103,12 +104,17 @@ int main(int argc, char *argv[])
 	std::cout << "id : " << device_id << "\n";
 	std::cout << "key : " << device_key<< "\n";
 	std::cout << "address : " << device_address << "\n";
+	std::cout << "version : " << device_version << "\n";
 #endif
 
 	unsigned char message_buffer[MAX_BUFFER_SIZE];
 
-	tuyaAPI33 *tuyaclient;
-	tuyaclient = new tuyaAPI33();
+	tuyaAPI *tuyaclient = tuyaAPI::create(device_version);
+	if (!tuyaclient)
+	{
+		std::cout << "Error: Unsupported protocol version " << device_version << "\n";
+		exit(0);
+	}
 
 	if (!tuyaclient->ConnectToDevice(device_address, TUYA_COMMAND_PORT))
 		error("ERROR connecting");

--- a/src/tuyaAPI.cpp
+++ b/src/tuyaAPI.cpp
@@ -1,0 +1,26 @@
+/*
+ *  Client interface for local Tuya device access
+ *
+ *  Copyright 2022-2024 - gordonb3 https://github.com/gordonb3/tuyapp
+ *
+ *  Licensed under GNU General Public License 3.0 or later.
+ *  Some rights reserved. See COPYING, AUTHORS.
+ *
+ *  @license GPL-3.0+ <https://github.com/gordonb3/tuyapp/blob/master/LICENSE>
+ */
+
+#include "tuyaAPI.hpp"
+#include "tuyaAPI31.hpp"
+#include "tuyaAPI33.hpp"
+#include "tuyaAPI34.hpp"
+
+tuyaAPI* tuyaAPI::create(const std::string &version)
+{
+	if (version == "3.1")
+		return new tuyaAPI31();
+	if (version == "3.3")
+		return new tuyaAPI33();
+	if (version == "3.4")
+		return new tuyaAPI34();
+	return nullptr;
+}

--- a/src/tuyaAPI.hpp
+++ b/src/tuyaAPI.hpp
@@ -1,0 +1,83 @@
+/*
+ *  Client interface for local Tuya device access
+ *
+ *  Copyright 2022-2024 - gordonb3 https://github.com/gordonb3/tuyapp
+ *
+ *  Licensed under GNU General Public License 3.0 or later.
+ *  Some rights reserved. See COPYING, AUTHORS.
+ *
+ *  @license GPL-3.0+ <https://github.com/gordonb3/tuyapp/blob/master/LICENSE>
+ */
+
+// Tuya API Base Class
+
+#ifndef _tuyaAPI
+#define _tuyaAPI
+
+// Tuya Command Types
+#define TUYA_UDP 0  // HEART_BEAT_CMD
+#define TUYA_AP_CONFIG 1  // PRODUCT_INFO_CMD
+#define TUYA_ACTIVE 2  // WORK_MODE_CMD
+#define TUYA_BIND 3  // WIFI_STATE_CMD - wifi working status
+#define TUYA_RENAME_GW 4  // WIFI_RESET_CMD - reset wifi
+#define TUYA_RENAME_DEVICE 5  // WIFI_MODE_CMD - Choose smartconfig/AP mode
+#define TUYA_UNBIND 6  // DATA_QUERT_CMD - issue command
+#define TUYA_CONTROL 7  // STATE_UPLOAD_CMD
+#define TUYA_STATUS 8  // STATE_QUERY_CMD
+#define TUYA_HEART_BEAT 9
+#define TUYA_DP_QUERY 10  // UPDATE_START_CMD - get data points
+#define TUYA_QUERY_WIFI 11  // UPDATE_TRANS_CMD
+#define TUYA_TOKEN_BIND 12  // GET_ONLINE_TIME_CMD - system time (GMT)
+#define TUYA_CONTROL_NEW 13  // FACTORY_MODE_CMD
+#define TUYA_ENABLE_WIFI 14  // WIFI_TEST_CMD
+#define TUYA_DP_QUERY_NEW 16
+#define TUYA_SCENE_EXECUTE 17
+#define TUYA_UPDATEDPS 18  // Request refresh of DPS
+#define TUYA_UDP_NEW 19
+#define TUYA_AP_CONFIG_NEW 20
+#define TUYA_GET_LOCAL_TIME_CMD 28
+#define TUYA_WEATHER_OPEN_CMD 32
+#define TUYA_WEATHER_DATA_CMD 33
+#define TUYA_STATE_UPLOAD_SYN_CMD 34
+#define TUYA_STATE_UPLOAD_SYN_RECV_CMD 35
+#define TUYA_HEART_BEAT_STOP 37
+#define TUYA_STREAM_TRANS_CMD 38
+#define TUYA_GET_WIFI_STATUS_CMD 43
+#define TUYA_WIFI_CONNECT_TEST_CMD 44
+#define TUYA_GET_MAC_CMD 45
+#define TUYA_GET_IR_STATUS_CMD 46
+#define TUYA_IR_TX_RX_TEST_CMD 47
+#define TUYA_LAN_GW_ACTIVE 240
+#define TUYA_LAN_SUB_DEV_REQUEST 241
+#define TUYA_LAN_DELETE_SUB_DEV 242
+#define TUYA_LAN_REPORT_SUB_DEV 243
+#define TUYA_LAN_SCENE 244
+#define TUYA_LAN_PUBLISH_CLOUD_CONFIG 245
+#define TUYA_LAN_PUBLISH_APP_CONFIG 246
+#define TUYA_LAN_EXPORT_APP_CONFIG 247
+#define TUYA_LAN_PUBLISH_SCENE_PANEL 248
+#define TUYA_LAN_REMOVE_GW 249
+#define TUYA_LAN_CHECK_GW_UPDATE 250
+#define TUYA_LAN_GW_UPDATE 251
+#define TUYA_LAN_SET_GW_CHANNEL 252
+
+#include <string>
+#include <cstdint>
+
+class tuyaAPI
+{
+public:
+	virtual ~tuyaAPI() {}
+
+	static tuyaAPI* create(const std::string &version);
+
+	virtual int BuildTuyaMessage(unsigned char *buffer, const uint8_t command, const std::string &payload, const std::string &encryption_key) = 0;
+	virtual std::string DecodeTuyaMessage(unsigned char* buffer, const int size, const std::string &encryption_key) = 0;
+
+	virtual bool ConnectToDevice(const std::string &hostname, const int portnumber, const uint8_t retries = 5) = 0;
+	virtual int send(unsigned char* buffer, const unsigned int size) = 0;
+	virtual int receive(unsigned char* buffer, const unsigned int maxsize, const unsigned int minsize = 28) = 0;
+	virtual void disconnect() = 0;
+};
+
+#endif

--- a/src/tuyaAPI31.cpp
+++ b/src/tuyaAPI31.cpp
@@ -167,7 +167,7 @@ int tuyaAPI31::BuildTuyaMessage(unsigned char *buffer, const uint8_t command, co
 }
 
 
-std::string tuyaAPI31::DecodeTuyaMessage(unsigned char* buffer, const int size)
+std::string tuyaAPI31::DecodeTuyaMessage(unsigned char* buffer, const int size, const std::string &encryption_key)
 {
 	std::string result;
 

--- a/src/tuyaAPI31.hpp
+++ b/src/tuyaAPI31.hpp
@@ -9,65 +9,17 @@
  *  @license GPL-3.0+ <https://github.com/gordonb3/tuyapp/blob/master/LICENSE>
  */
 
-// Tuya API 3.3 Class
+// Tuya API 3.1 Class
 
 #ifndef _tuyaAPI31
 #define _tuyaAPI31
 
-
-// Tuya Command Types
-#define TUYA_UDP 0  // HEART_BEAT_CMD
-#define TUYA_AP_CONFIG 1  // PRODUCT_INFO_CMD
-#define TUYA_ACTIVE 2  // WORK_MODE_CMD
-#define TUYA_BIND 3  // WIFI_STATE_CMD - wifi working status
-#define TUYA_RENAME_GW 4  // WIFI_RESET_CMD - reset wifi
-#define TUYA_RENAME_DEVICE 5  // WIFI_MODE_CMD - Choose smartconfig/AP mode
-#define TUYA_UNBIND 6  // DATA_QUERT_CMD - issue command
-#define TUYA_CONTROL 7  // STATE_UPLOAD_CMD
-#define TUYA_STATUS 8  // STATE_QUERY_CMD
-#define TUYA_HEART_BEAT 9
-#define TUYA_DP_QUERY 10  // UPDATE_START_CMD - get data points
-#define TUYA_QUERY_WIFI 11  // UPDATE_TRANS_CMD
-#define TUYA_TOKEN_BIND 12  // GET_ONLINE_TIME_CMD - system time (GMT)
-#define TUYA_CONTROL_NEW 13  // FACTORY_MODE_CMD
-#define TUYA_ENABLE_WIFI 14  // WIFI_TEST_CMD
-#define TUYA_DP_QUERY_NEW 16
-#define TUYA_SCENE_EXECUTE 17
-#define TUYA_UPDATEDPS 18  // Request refresh of DPS
-#define TUYA_UDP_NEW 19
-#define TUYA_AP_CONFIG_NEW 20
-#define TUYA_GET_LOCAL_TIME_CMD 28
-#define TUYA_WEATHER_OPEN_CMD 32
-#define TUYA_WEATHER_DATA_CMD 33
-#define TUYA_STATE_UPLOAD_SYN_CMD 34
-#define TUYA_STATE_UPLOAD_SYN_RECV_CMD 35
-#define TUYA_HEART_BEAT_STOP 37
-#define TUYA_STREAM_TRANS_CMD 38
-#define TUYA_GET_WIFI_STATUS_CMD 43
-#define TUYA_WIFI_CONNECT_TEST_CMD 44
-#define TUYA_GET_MAC_CMD 45
-#define TUYA_GET_IR_STATUS_CMD 46
-#define TUYA_IR_TX_RX_TEST_CMD 47
-#define TUYA_LAN_GW_ACTIVE 240
-#define TUYA_LAN_SUB_DEV_REQUEST 241
-#define TUYA_LAN_DELETE_SUB_DEV 242
-#define TUYA_LAN_REPORT_SUB_DEV 243
-#define TUYA_LAN_SCENE 244
-#define TUYA_LAN_PUBLISH_CLOUD_CONFIG 245
-#define TUYA_LAN_PUBLISH_APP_CONFIG 246
-#define TUYA_LAN_EXPORT_APP_CONFIG 247
-#define TUYA_LAN_PUBLISH_SCENE_PANEL 248
-#define TUYA_LAN_REMOVE_GW 249
-#define TUYA_LAN_CHECK_GW_UPDATE 250
-#define TUYA_LAN_GW_UPDATE 251
-#define TUYA_LAN_SET_GW_CHANNEL 252
-
-
+#include "tuyaAPI.hpp"
 
 #include <string>
 #include <cstdint>
 
-class tuyaAPI31
+class tuyaAPI31 : public tuyaAPI
 {
 
 public:
@@ -79,13 +31,13 @@ public:
 	tuyaAPI31();
 	~tuyaAPI31();
 
-	int BuildTuyaMessage(unsigned char *buffer, const uint8_t command, const std::string &payload, const std::string &encryption_key);
-	std::string DecodeTuyaMessage(unsigned char* buffer, const int size);
+	int BuildTuyaMessage(unsigned char *buffer, const uint8_t command, const std::string &payload, const std::string &encryption_key) override;
+	std::string DecodeTuyaMessage(unsigned char* buffer, const int size, const std::string &encryption_key) override;
 
-	bool ConnectToDevice(const std::string &hostname, const int portnumber, const uint8_t retries);
-	int send(unsigned char* buffer, const unsigned int size);
-	int receive(unsigned char* buffer, const unsigned int maxsize, const unsigned int minsize);
-	void disconnect();
+	bool ConnectToDevice(const std::string &hostname, const int portnumber, const uint8_t retries = 5) override;
+	int send(unsigned char* buffer, const unsigned int size) override;
+	int receive(unsigned char* buffer, const unsigned int maxsize, const unsigned int minsize = 28) override;
+	void disconnect() override;
 
 
 private:

--- a/src/tuyaAPI33.hpp
+++ b/src/tuyaAPI33.hpp
@@ -14,60 +14,12 @@
 #ifndef _tuyaAPI33
 #define _tuyaAPI33
 
-
-// Tuya Command Types
-#define TUYA_UDP 0  // HEART_BEAT_CMD
-#define TUYA_AP_CONFIG 1  // PRODUCT_INFO_CMD
-#define TUYA_ACTIVE 2  // WORK_MODE_CMD
-#define TUYA_BIND 3  // WIFI_STATE_CMD - wifi working status
-#define TUYA_RENAME_GW 4  // WIFI_RESET_CMD - reset wifi
-#define TUYA_RENAME_DEVICE 5  // WIFI_MODE_CMD - Choose smartconfig/AP mode
-#define TUYA_UNBIND 6  // DATA_QUERT_CMD - issue command
-#define TUYA_CONTROL 7  // STATE_UPLOAD_CMD
-#define TUYA_STATUS 8  // STATE_QUERY_CMD
-#define TUYA_HEART_BEAT 9
-#define TUYA_DP_QUERY 10  // UPDATE_START_CMD - get data points
-#define TUYA_QUERY_WIFI 11  // UPDATE_TRANS_CMD
-#define TUYA_TOKEN_BIND 12  // GET_ONLINE_TIME_CMD - system time (GMT)
-#define TUYA_CONTROL_NEW 13  // FACTORY_MODE_CMD
-#define TUYA_ENABLE_WIFI 14  // WIFI_TEST_CMD
-#define TUYA_DP_QUERY_NEW 16
-#define TUYA_SCENE_EXECUTE 17
-#define TUYA_UPDATEDPS 18  // Request refresh of DPS
-#define TUYA_UDP_NEW 19
-#define TUYA_AP_CONFIG_NEW 20
-#define TUYA_GET_LOCAL_TIME_CMD 28
-#define TUYA_WEATHER_OPEN_CMD 32
-#define TUYA_WEATHER_DATA_CMD 33
-#define TUYA_STATE_UPLOAD_SYN_CMD 34
-#define TUYA_STATE_UPLOAD_SYN_RECV_CMD 35
-#define TUYA_HEART_BEAT_STOP 37
-#define TUYA_STREAM_TRANS_CMD 38
-#define TUYA_GET_WIFI_STATUS_CMD 43
-#define TUYA_WIFI_CONNECT_TEST_CMD 44
-#define TUYA_GET_MAC_CMD 45
-#define TUYA_GET_IR_STATUS_CMD 46
-#define TUYA_IR_TX_RX_TEST_CMD 47
-#define TUYA_LAN_GW_ACTIVE 240
-#define TUYA_LAN_SUB_DEV_REQUEST 241
-#define TUYA_LAN_DELETE_SUB_DEV 242
-#define TUYA_LAN_REPORT_SUB_DEV 243
-#define TUYA_LAN_SCENE 244
-#define TUYA_LAN_PUBLISH_CLOUD_CONFIG 245
-#define TUYA_LAN_PUBLISH_APP_CONFIG 246
-#define TUYA_LAN_EXPORT_APP_CONFIG 247
-#define TUYA_LAN_PUBLISH_SCENE_PANEL 248
-#define TUYA_LAN_REMOVE_GW 249
-#define TUYA_LAN_CHECK_GW_UPDATE 250
-#define TUYA_LAN_GW_UPDATE 251
-#define TUYA_LAN_SET_GW_CHANNEL 252
-
-
+#include "tuyaAPI.hpp"
 
 #include <string>
 #include <cstdint>
 
-class tuyaAPI33
+class tuyaAPI33 : public tuyaAPI
 {
 
 public:
@@ -79,13 +31,13 @@ public:
 	tuyaAPI33();
 	~tuyaAPI33();
 
-	int BuildTuyaMessage(unsigned char *buffer, const uint8_t command, const std::string &payload, const std::string &encryption_key);
-	std::string DecodeTuyaMessage(unsigned char* buffer, const int size, const std::string &encryption_key);
+	int BuildTuyaMessage(unsigned char *buffer, const uint8_t command, const std::string &payload, const std::string &encryption_key) override;
+	std::string DecodeTuyaMessage(unsigned char* buffer, const int size, const std::string &encryption_key) override;
 
-	bool ConnectToDevice(const std::string &hostname, const int portnumber, const uint8_t retries = 5);
-	int send(unsigned char* buffer, const unsigned int size);
-	int receive(unsigned char* buffer, const unsigned int maxsize, const unsigned int minsize = 28);
-	void disconnect();
+	bool ConnectToDevice(const std::string &hostname, const int portnumber, const uint8_t retries = 5) override;
+	int send(unsigned char* buffer, const unsigned int size) override;
+	int receive(unsigned char* buffer, const unsigned int maxsize, const unsigned int minsize = 28) override;
+	void disconnect() override;
 
 
 private:

--- a/src/tuyaAPI34.hpp
+++ b/src/tuyaAPI34.hpp
@@ -14,60 +14,12 @@
 #ifndef _tuyaAPI34
 #define _tuyaAPI34
 
-
-// Tuya Command Types
-#define TUYA_UDP 0  // HEART_BEAT_CMD
-#define TUYA_AP_CONFIG 1  // PRODUCT_INFO_CMD
-#define TUYA_ACTIVE 2  // WORK_MODE_CMD
-#define TUYA_BIND 3  // WIFI_STATE_CMD - wifi working status
-#define TUYA_RENAME_GW 4  // WIFI_RESET_CMD - reset wifi
-#define TUYA_RENAME_DEVICE 5  // WIFI_MODE_CMD - Choose smartconfig/AP mode
-#define TUYA_UNBIND 6  // DATA_QUERT_CMD - issue command
-#define TUYA_CONTROL 7  // STATE_UPLOAD_CMD
-#define TUYA_STATUS 8  // STATE_QUERY_CMD
-#define TUYA_HEART_BEAT 9
-#define TUYA_DP_QUERY 10  // UPDATE_START_CMD - get data points
-#define TUYA_QUERY_WIFI 11  // UPDATE_TRANS_CMD
-#define TUYA_TOKEN_BIND 12  // GET_ONLINE_TIME_CMD - system time (GMT)
-#define TUYA_CONTROL_NEW 13  // FACTORY_MODE_CMD
-#define TUYA_ENABLE_WIFI 14  // WIFI_TEST_CMD
-#define TUYA_DP_QUERY_NEW 16
-#define TUYA_SCENE_EXECUTE 17
-#define TUYA_UPDATEDPS 18  // Request refresh of DPS
-#define TUYA_UDP_NEW 19
-#define TUYA_AP_CONFIG_NEW 20
-#define TUYA_GET_LOCAL_TIME_CMD 28
-#define TUYA_WEATHER_OPEN_CMD 32
-#define TUYA_WEATHER_DATA_CMD 33
-#define TUYA_STATE_UPLOAD_SYN_CMD 34
-#define TUYA_STATE_UPLOAD_SYN_RECV_CMD 35
-#define TUYA_HEART_BEAT_STOP 37
-#define TUYA_STREAM_TRANS_CMD 38
-#define TUYA_GET_WIFI_STATUS_CMD 43
-#define TUYA_WIFI_CONNECT_TEST_CMD 44
-#define TUYA_GET_MAC_CMD 45
-#define TUYA_GET_IR_STATUS_CMD 46
-#define TUYA_IR_TX_RX_TEST_CMD 47
-#define TUYA_LAN_GW_ACTIVE 240
-#define TUYA_LAN_SUB_DEV_REQUEST 241
-#define TUYA_LAN_DELETE_SUB_DEV 242
-#define TUYA_LAN_REPORT_SUB_DEV 243
-#define TUYA_LAN_SCENE 244
-#define TUYA_LAN_PUBLISH_CLOUD_CONFIG 245
-#define TUYA_LAN_PUBLISH_APP_CONFIG 246
-#define TUYA_LAN_EXPORT_APP_CONFIG 247
-#define TUYA_LAN_PUBLISH_SCENE_PANEL 248
-#define TUYA_LAN_REMOVE_GW 249
-#define TUYA_LAN_CHECK_GW_UPDATE 250
-#define TUYA_LAN_GW_UPDATE 251
-#define TUYA_LAN_SET_GW_CHANNEL 252
-
-
+#include "tuyaAPI.hpp"
 
 #include <string>
 #include <cstdint>
 
-class tuyaAPI34
+class tuyaAPI34 : public tuyaAPI
 {
 
 public:
@@ -79,13 +31,13 @@ public:
 	tuyaAPI34();
 	~tuyaAPI34();
 
-	int BuildTuyaMessage(unsigned char *buffer, const uint8_t command, const std::string &payload, const std::string &encryption_key);
-	std::string DecodeTuyaMessage(unsigned char* buffer, const int size, const std::string &encryption_key);
+	int BuildTuyaMessage(unsigned char *buffer, const uint8_t command, const std::string &payload, const std::string &encryption_key) override;
+	std::string DecodeTuyaMessage(unsigned char* buffer, const int size, const std::string &encryption_key) override;
 
-	bool ConnectToDevice(const std::string &hostname, const int portnumber, const uint8_t retries = 5);
-	int send(unsigned char* buffer, const unsigned int size);
-	int receive(unsigned char* buffer, const unsigned int maxsize, const unsigned int minsize = 28);
-	void disconnect();
+	bool ConnectToDevice(const std::string &hostname, const int portnumber, const uint8_t retries = 5) override;
+	int send(unsigned char* buffer, const unsigned int size) override;
+	int receive(unsigned char* buffer, const unsigned int maxsize, const unsigned int minsize = 28) override;
+	void disconnect() override;
 
 
 private:

--- a/tuya-devices.json.sample
+++ b/tuya-devices.json.sample
@@ -3,18 +3,20 @@
 		{"address":"192.168.10.91",
 		 "id":"123456789abcdef12345",
 		 "key":"abcdef1234567890",
-		 "name":"tuya1"
+		 "name":"tuya1",
+		 "version":"3.3"
 		},
 		{"address":"192.168.10.92",
 		 "id":"123456789abcdef23456",
 		 "key":"abcdef1234567890",
-		 "name":"tuya2"
+		 "name":"tuya2",
+		 "version":"3.3"
 		},
 		{"address":"192.168.10.93",
 		 "id":"123456789abcdef34567",
 		 "key":"abcdef1234567890",
-		 "name":"tuya3"
+		 "name":"tuya3",
+		 "version":"3.3"
 		}
 	]
 }
-


### PR DESCRIPTION
- Create tuyaAPI base class with pure virtual methods
- Make tuyaAPI31, tuyaAPI33, tuyaAPI34 inherit from base class
- Add factory method tuyaAPI::create(version) for instantiation
- Move TUYA command constants to base class header
- Add version field to tuya-devices.json
- Update examples to use factory pattern with version from JSON
- Standardize DecodeTuyaMessage signature across all protocols