### PR TITLE
Fixes for v3.4 protocol control commands

### DIFF
--- a/examples/tuya_switch.cpp
+++ b/examples/tuya_switch.cpp
@@ -170,21 +170,40 @@ int main(int argc, char *argv[])
 
 
 	ss_payload.str(std::string());
-	ss_payload << "{\"devId\":\"" << device_id << "\",\"uid\":\"" << device_id << "\",\"dps\":{\"1\":";
-	if (switchstate)
-		ss_payload << "true";
+
+	// Protocol 3.4 uses different payload format
+	if (tuyaclient->getProtocol() == tuyaAPI::Protocol::v34)
+	{
+		ss_payload << "{\"protocol\":5,\"t\":" << currenttime << ",\"data\":{\"dps\":{\"1\":";
+		if (switchstate)
+			ss_payload << "true";
+		else
+			ss_payload << "false";
+		if (countdown)
+			ss_payload << ",\"9\":" << countdown;
+		ss_payload <<  "}}}";
+	}
 	else
-		ss_payload << "false";
-	if (countdown)
-		ss_payload << ",\"9\":" << countdown;
-	ss_payload <<  "},\"t\":\"" << currenttime << "\"}";
+	{
+		// Protocol 3.3 and earlier use devId/uid format
+		ss_payload << "{\"devId\":\"" << device_id << "\",\"uid\":\"" << device_id << "\",\"dps\":{\"1\":";
+		if (switchstate)
+			ss_payload << "true";
+		else
+			ss_payload << "false";
+		if (countdown)
+			ss_payload << ",\"9\":" << countdown;
+		ss_payload <<  "},\"t\":\"" << currenttime << "\"}";
+	}
 	payload = ss_payload.str();
 
 #ifdef DEBUG
 	std::cout << "building switch payload: " << payload << "\n";
 #endif
 
-	payload_len = tuyaclient->BuildTuyaMessage(message_buffer, TUYA_CONTROL, payload, device_key);
+	payload_len = tuyaclient->BuildTuyaMessage(message_buffer,
+		(tuyaclient->getProtocol() == tuyaAPI::Protocol::v34) ? TUYA_CONTROL_NEW : TUYA_CONTROL,
+		payload, device_key);
 
 #ifdef DEBUG
 		std::cout << "sending message: ";

--- a/src/tuyaAPI.hpp
+++ b/src/tuyaAPI.hpp
@@ -73,13 +73,24 @@
 class tuyaAPI : public tuyaTCP
 {
 public:
+	enum class Protocol {
+		v31,
+		v33,
+		v34
+	};
+
 	virtual ~tuyaAPI() {}
 
 	static tuyaAPI* create(const std::string &version);
 
+	// Get protocol version
+	Protocol getProtocol() const { return m_protocol; }
+
 	virtual int BuildTuyaMessage(unsigned char *buffer, const uint8_t command, const std::string &payload, const std::string &encryption_key) = 0;
 	virtual std::string DecodeTuyaMessage(unsigned char* buffer, const int size, const std::string &encryption_key) = 0;
 
+protected:
+	Protocol m_protocol;
 };
 
 #endif

--- a/src/tuyaAPI31.hpp
+++ b/src/tuyaAPI31.hpp
@@ -23,6 +23,7 @@ class tuyaAPI31 : public tuyaAPI
 {
 
 public:
+	tuyaAPI31() { m_protocol = Protocol::v31; }
 
 	int BuildTuyaMessage(unsigned char *buffer, const uint8_t command, const std::string &payload, const std::string &encryption_key) override;
 	std::string DecodeTuyaMessage(unsigned char* buffer, const int size, const std::string &encryption_key) override;

--- a/src/tuyaAPI33.hpp
+++ b/src/tuyaAPI33.hpp
@@ -23,6 +23,7 @@ class tuyaAPI33 : public tuyaAPI
 {
 
 public:
+	tuyaAPI33() { m_protocol = Protocol::v33; }
 
 	int BuildTuyaMessage(unsigned char *buffer, const uint8_t command, const std::string &payload, const std::string &encryption_key) override;
 	std::string DecodeTuyaMessage(unsigned char* buffer, const int size, const std::string &encryption_key) override;

--- a/src/tuyaAPI34.cpp
+++ b/src/tuyaAPI34.cpp
@@ -31,6 +31,7 @@
 
 tuyaAPI34::tuyaAPI34()
 {
+	m_protocol = Protocol::v34;
 	m_session_established = false;
 	m_seqno = 0;
 }

--- a/src/tuyaAPI34.cpp
+++ b/src/tuyaAPI34.cpp
@@ -16,7 +16,6 @@
 #define MESSAGE_TRAILER_SIZE 36
 
 #include "tuyaAPI34.hpp"
-#include <zlib.h>
 #include <cstring>
 #include <thread>
 #include <openssl/evp.h>
@@ -143,10 +142,6 @@ std::string tuyaAPI34::DecodeTuyaMessage(unsigned char* buffer, const int size, 
 			bufferpos += messageSize;
 			continue;
 		}
-
-		unsigned int crc_sent = ((uint8_t)cTuyaResponse[messageSize - 8] << 24) + ((uint8_t)cTuyaResponse[messageSize - 7] << 16) + ((uint8_t)cTuyaResponse[messageSize - 6] << 8) + (uint8_t)cTuyaResponse[messageSize - 5];
-		unsigned int crc = crc32(0L, Z_NULL, 0) & 0xFFFFFFFF;
-		crc = crc32(crc, cTuyaResponse, messageSize - 8) & 0xFFFFFFFF;
 
 		// For v3.4, verify HMAC instead of CRC
 		unsigned char hmac_sent[32];

--- a/src/tuyaAPI34.cpp
+++ b/src/tuyaAPI34.cpp
@@ -46,6 +46,15 @@ int tuyaAPI34::BuildTuyaMessage(unsigned char *buffer, const uint8_t command, co
 
 	m_seqno++;
 
+	// For control commands (7, 13), protocol 3.4 requires "3.4" prefix + 12 null bytes
+	std::string payload = szPayload;
+	if (command == TUYA_CONTROL || command == TUYA_CONTROL_NEW)
+	{
+		payload = "3.4";
+		payload.append(12, '\0');
+		payload.append(szPayload);
+	}
+
 	int bufferpos = 0;
 	memset(buffer, 0, PROTOCOL_34_HEADER_SIZE);
 	buffer[0] = (MESSAGE_PREFIX & 0xFF000000) >> 24;
@@ -60,11 +69,11 @@ int tuyaAPI34::BuildTuyaMessage(unsigned char *buffer, const uint8_t command, co
 	bufferpos += (int)PROTOCOL_34_HEADER_SIZE;
 
 #ifdef DEBUG
-	std::cout << "dbg: Payload to encrypt (" << szPayload.length() << " bytes): " << szPayload << "\n";
+	std::cout << "dbg: Payload to encrypt (" << payload.length() << " bytes): " << payload << "\n";
 #endif
 
 	unsigned char* cEncryptedPayload = &buffer[bufferpos];
-	int payloadSize = (int)szPayload.length();
+	int payloadSize = (int)payload.length();
 	memset(cEncryptedPayload, 0, payloadSize + 16);
 	int encryptedSize = 0;
 	int encryptedChars = 0;
@@ -73,7 +82,7 @@ int tuyaAPI34::BuildTuyaMessage(unsigned char *buffer, const uint8_t command, co
 	{
 		EVP_CIPHER_CTX* ctx = EVP_CIPHER_CTX_new();
 		EVP_EncryptInit_ex(ctx, EVP_aes_128_ecb(), nullptr, m_session_key, nullptr);
-		EVP_EncryptUpdate(ctx, cEncryptedPayload, &encryptedChars, (unsigned char*)szPayload.c_str(), payloadSize);
+		EVP_EncryptUpdate(ctx, cEncryptedPayload, &encryptedChars, (unsigned char*)payload.c_str(), payloadSize);
 		encryptedSize = encryptedChars;
 		EVP_EncryptFinal_ex(ctx, cEncryptedPayload + encryptedChars, &encryptedChars);
 		encryptedSize += encryptedChars;


### PR DESCRIPTION
#### 1. Add protocol 3.4 prefix for control commands
Protocol 3.4 requires control commands to have a "3.4" prefix followed by 12 null bytes before the JSON payload. This is now automatically added in `BuildTuyaMessage()`.

#### 2. Add protocol version enum
Adds a `Protocol` enum (v31, v33, v34) to the base class with a `getProtocol()` method, allowing applications to query the protocol version and adapt their behavior accordingly.

#### 3. Fix tuya_switch for all protocols
Updates `tuya_switch` example to:
- Check protocol version and format payloads correctly for each version
- Protocol 3.4: uses `{"protocol":5,"t":...,"data":{"dps":{...}}}`
- Protocol 3.3/3.1: uses `{"devId":...,"uid":...,"dps":{...},"t":...}`
- Use `TUYA_CONTROL_NEW` (cmd 13) for protocol 3.4, `TUYA_CONTROL` (cmd 7) for earlier versions

#### 4. Remove unused CRC code
Protocol 3.4 uses HMAC-SHA256 for integrity checking, not CRC32. Removes unused CRC variables and zlib include from `tuyaAPI34.cpp`, eliminating a compiler warning.

### Testing
Tested with protocol 3.4 device - `tuya_switch` now successfully turns devices on and off.
