### PR TITLE
Allow truly asynchronous session negotiation without use of the base TCP class methods

### DIFF
--- a/examples/simple_energy_monitor.cpp
+++ b/examples/simple_energy_monitor.cpp
@@ -43,8 +43,11 @@ int main(int argc, char *argv[])
 	std::string device_id = std::string(argv[2]);
 	std::string device_key = std::string(argv[3]);
 
+	if (!tuyaclient->NegotiateSession(device_key))
+		c_error("ERROR negotiating session");
+
 	std::string szPayload = tuyaclient->GeneratePayload(TUYA_DP_QUERY, device_id, "");
-	int payload_len = tuyaclient->BuildTuyaMessage(message_buffer, TUYA_DP_QUERY, szPayload, device_key);
+	int payload_len = tuyaclient->BuildTuyaMessage(message_buffer, TUYA_DP_QUERY, szPayload);
 
 	int numbytes = tuyaclient->send(message_buffer, payload_len);
 	if (numbytes < 0)
@@ -55,7 +58,7 @@ int main(int argc, char *argv[])
 	if (numbytes < 0)
 		c_error("ERROR reading from socket");
 
-	std::string tuyaresponse = tuyaclient->DecodeTuyaMessage(message_buffer, numbytes, device_key);
+	std::string tuyaresponse = tuyaclient->DecodeTuyaMessage(message_buffer, numbytes);
 
 #ifdef APPDEBUG
 	std::cout << "dbg: raw answer: ";
@@ -71,7 +74,7 @@ int main(int argc, char *argv[])
 		usleep(100000);
 
 		szPayload = "{\"dpId\":[1,19]}";
-		payload_len = tuyaclient->BuildTuyaMessage(message_buffer, TUYA_UPDATEDPS, szPayload, device_key);
+		payload_len = tuyaclient->BuildTuyaMessage(message_buffer, TUYA_UPDATEDPS, szPayload);
 		numbytes = tuyaclient->send(message_buffer, payload_len);
 		if (numbytes < 0)
 			c_error("ERROR writing to socket");

--- a/examples/simple_switch.cpp
+++ b/examples/simple_switch.cpp
@@ -47,6 +47,10 @@ int main(int argc, char *argv[])
 	std::string device_id = std::string(argv[2]);
 	std::string device_key = std::string(argv[3]);
 	std::string s_switchstate = std::string(argv[4]);
+
+	if (!tuyaclient->NegotiateSession(device_key))
+		c_error("ERROR negotiating session");
+
 	int countdown = 0;
 	if (argc > 5)
 		countdown = atoi(argv[5]);
@@ -57,7 +61,7 @@ int main(int argc, char *argv[])
 	ss_payload << "{\"gwId\":\"" << device_id << "\",\"devId\":\"" << device_id << "\",\"uid\":\"" << device_id << "\",\"t\":\"" << currenttime << "\"}";
 	std::string payload = ss_payload.str();
 
-	int payload_len = tuyaclient->BuildTuyaMessage(message_buffer, TUYA_DP_QUERY, payload, device_key);
+	int payload_len = tuyaclient->BuildTuyaMessage(message_buffer, TUYA_DP_QUERY, payload);
 
 	int numbytes = tuyaclient->send(message_buffer, payload_len);
 	if (numbytes < 0)
@@ -66,7 +70,7 @@ int main(int argc, char *argv[])
 	if (numbytes < 0)
 		c_error("ERROR reading from socket");
 
-	std::string tuyaresponse = tuyaclient->DecodeTuyaMessage(message_buffer, numbytes, device_key);
+	std::string tuyaresponse = tuyaclient->DecodeTuyaMessage(message_buffer, numbytes);
 
 #ifdef APPDEBUG
 	std::cout << "dbg: raw answer: ";
@@ -111,7 +115,7 @@ int main(int argc, char *argv[])
 	std::cout << "building switch payload: " << payload << "\n";
 #endif
 
-	payload_len = tuyaclient->BuildTuyaMessage(message_buffer, TUYA_CONTROL, payload, device_key);
+	payload_len = tuyaclient->BuildTuyaMessage(message_buffer, TUYA_CONTROL, payload);
 
 #ifdef APPDEBUG
 		std::cout << "sending message: ";
@@ -130,7 +134,7 @@ int main(int argc, char *argv[])
 		c_error("ERROR reading from socket");
 
 
-	tuyaresponse = tuyaclient->DecodeTuyaMessage(message_buffer, numbytes, device_key);
+	tuyaresponse = tuyaclient->DecodeTuyaMessage(message_buffer, numbytes);
 #ifdef APPDEBUG
 	std::cout << "dbg: raw answer: ";
 	for(int i=0; i<numbytes; ++i)

--- a/examples/tuya_kwh_meter.cpp
+++ b/examples/tuya_kwh_meter.cpp
@@ -112,8 +112,14 @@ int main(int argc, char *argv[])
 		exit(1);
 	}
 
+	if (!tuyaclient->NegotiateSession(device_key))
+	{
+		std::cout << "Error negotiating session\n";
+		exit(1);
+	}
+
 	std::string szPayload = tuyaclient->GeneratePayload(TUYA_DP_QUERY, device_id, "");
-	int payload_len = tuyaclient->BuildTuyaMessage(message_buffer, TUYA_DP_QUERY, szPayload, device_key);
+	int payload_len = tuyaclient->BuildTuyaMessage(message_buffer, TUYA_DP_QUERY, szPayload);
 
 	int numbytes = tuyaclient->send(message_buffer, payload_len);
 	if (numbytes < 0)
@@ -132,7 +138,7 @@ int main(int argc, char *argv[])
 		exit(1);
 	}
 
-	std::string tuyaresponse = tuyaclient->DecodeTuyaMessage(message_buffer, numbytes, device_key);
+	std::string tuyaresponse = tuyaclient->DecodeTuyaMessage(message_buffer, numbytes);
 
 #ifdef APPDEBUG
 	std::cout << "dbg: raw answer: ";
@@ -159,13 +165,13 @@ int main(int argc, char *argv[])
 		{
 			// received data => make new request for data point updates for switch state, power and voltage
 			szPayload = "{\"dpId\":[1,19]}";
-			payload_len = tuyaclient->BuildTuyaMessage(message_buffer, TUYA_UPDATEDPS, szPayload, device_key);
+			payload_len = tuyaclient->BuildTuyaMessage(message_buffer, TUYA_UPDATEDPS, szPayload);
 		}
 		else
 		{
 			// send heart beat to keep connection alive
 			szPayload = tuyaclient->GeneratePayload(TUYA_HEART_BEAT, device_id, "");
-			payload_len = tuyaclient->BuildTuyaMessage(message_buffer, TUYA_HEART_BEAT, szPayload, device_key);
+			payload_len = tuyaclient->BuildTuyaMessage(message_buffer, TUYA_HEART_BEAT, szPayload);
 		}
 
 		numbytes = tuyaclient->send(message_buffer, payload_len);

--- a/examples/tuya_status.cpp
+++ b/examples/tuya_status.cpp
@@ -109,13 +109,14 @@ int main(int argc, char *argv[])
 		exit(0);
 	}
 
-	std::string payload = tuyaclient->GeneratePayload(TUYA_DP_QUERY, device_id, "");
-	int payload_len = tuyaclient->BuildTuyaMessage(message_buffer, TUYA_DP_QUERY, payload, device_key);
-	if (payload_len < 0)
+	if (!tuyaclient->NegotiateSession(device_key))
 	{
-		std::cout << "Error negotiating session, socket returned:"  << strerror(tuyaclient->getlasterror()) << " (" << tuyaclient->getlasterror() << ")\n";
+		std::cout << "Error negotiating session\n";
 		exit(1);
 	}
+
+	std::string payload = tuyaclient->GeneratePayload(TUYA_DP_QUERY, device_id, "");
+	int payload_len = tuyaclient->BuildTuyaMessage(message_buffer, TUYA_DP_QUERY, payload);
 
 	int numbytes;
 	numbytes = tuyaclient->send(message_buffer, payload_len);
@@ -129,7 +130,7 @@ int main(int argc, char *argv[])
 		exit(1);
 	}
 
-	std::string tuyaresponse = tuyaclient->DecodeTuyaMessage(message_buffer, numbytes, device_key);
+	std::string tuyaresponse = tuyaclient->DecodeTuyaMessage(message_buffer, numbytes);
 
 #ifdef APPDEBUG
 	std::cout << "dbg: raw answer: ";

--- a/examples/tuya_switch.cpp
+++ b/examples/tuya_switch.cpp
@@ -113,18 +113,19 @@ int main(int argc, char *argv[])
 	if (!tuyaclient->ConnectToDevice(device_address))
 		error("ERROR connecting");
 
+	if (!tuyaclient->NegotiateSession(device_key))
+	{
+		std::cout << "Error negotiating session\n";
+		exit(1);
+	}
+
 	std::string s_switchstate = std::string(argv[2]);
 	int countdown = 0;
 	if (argc > 3)
 		countdown = atoi(argv[3]);
 
 	std::string payload = tuyaclient->GeneratePayload(TUYA_DP_QUERY, device_id, "");
-	int payload_len = tuyaclient->BuildTuyaMessage(message_buffer, TUYA_DP_QUERY, payload, device_key);
-	if (payload_len < 0)
-	{
-		std::cout << "Error negotiating session, socket returned:"  << strerror(tuyaclient->getlasterror()) << " (" << tuyaclient->getlasterror() << ")\n";
-		exit(1);
-	}
+	int payload_len = tuyaclient->BuildTuyaMessage(message_buffer, TUYA_DP_QUERY, payload);
 
 	int numbytes = tuyaclient->send(message_buffer, payload_len);
 	if (numbytes < 0)
@@ -134,7 +135,7 @@ int main(int argc, char *argv[])
 	if (numbytes < 0)
 		error("ERROR reading from socket");
 
-	std::string tuyaresponse = tuyaclient->DecodeTuyaMessage(message_buffer, numbytes, device_key);
+	std::string tuyaresponse = tuyaclient->DecodeTuyaMessage(message_buffer, numbytes);
 
 #ifdef APPDEBUG
 	std::cout << "dbg: raw answer: ";
@@ -203,7 +204,7 @@ int main(int argc, char *argv[])
 	if (numbytes < 0)
 		error("ERROR reading from socket");
 
-	tuyaresponse = tuyaclient->DecodeTuyaMessage(message_buffer, numbytes, device_key);
+	tuyaresponse = tuyaclient->DecodeTuyaMessage(message_buffer, numbytes);
 #ifdef APPDEBUG
 	std::cout << "dbg: raw encrypted answer: ";
 	for(int i=0; i<numbytes; ++i)

--- a/src/tuyaAPI.cpp
+++ b/src/tuyaAPI.cpp
@@ -29,6 +29,9 @@ namespace Tuya {
   }; // namespace Commands
 }; // namespace Tuya
 
+#ifdef DEBUG
+#include <iostream>
+#endif
 
 tuyaAPI* tuyaAPI::create(const std::string &version)
 {
@@ -41,6 +44,52 @@ tuyaAPI* tuyaAPI::create(const std::string &version)
 	return nullptr;
 }
 
+bool tuyaAPI::NegotiateSession(const std::string &local_key)
+{
+	SetEncryptionKey(local_key);
+	m_session_established = false;
+
+	unsigned char send_buffer[1024];
+	unsigned char recv_buffer[1024];
+
+	while (!m_session_established)
+	{
+		int packet_size = BuildSessionMessage(send_buffer);
+		if (packet_size < 0)
+			return false;
+		if (packet_size == 0)
+			break;
+
+#ifdef DEBUG
+		std::cout << "dbg: session message (size=" << packet_size << "): ";
+		for(int i=0; i<packet_size; ++i)
+			printf("%.2x", (uint8_t)send_buffer[i]);
+		std::cout << "\n";
+#endif
+
+		if (send(send_buffer, packet_size) < 0)
+			return false;
+
+		if (m_session_established)
+			break;
+
+		int recv_size = receive(recv_buffer, sizeof(recv_buffer), 0);
+		if (recv_size < 0)
+			return false;
+
+#ifdef DEBUG
+		std::cout << "dbg: received session message (size=" << recv_size << "): ";
+		for(int i=0; i<recv_size; ++i)
+			printf("%.2x", (uint8_t)recv_buffer[i]);
+		std::cout << "\n";
+#endif
+
+
+		DecodeSessionMessage(recv_buffer, recv_size);
+	}
+
+	return true;
+}
 
 std::string tuyaAPI::GeneratePayload(const uint8_t command, const std::string &szDeviceID, const std::string &szDatapoints)
 {
@@ -76,4 +125,3 @@ std::string tuyaAPI::GeneratePayload(const uint8_t command, const std::string &s
 	}
 	return szPayload;
 }
-

--- a/src/tuyaAPI.hpp
+++ b/src/tuyaAPI.hpp
@@ -87,18 +87,22 @@ public:
 	Protocol getProtocol() const { return m_protocol; }
 
 	virtual void SetEncryptionKey(const std::string &key) { m_device_key = key; }
-	virtual bool NegotiateSession(const std::string &local_key) { SetEncryptionKey(local_key); return true; }
+	bool NegotiateSession(const std::string &local_key);
+	bool isSessionEstablished() const { return m_session_established; }
 
 	std::string GeneratePayload(const uint8_t command, const std::string &szDeviceID, const std::string &szDatapoints);
 	virtual int BuildTuyaMessage(unsigned char *buffer, const uint8_t command, const std::string &payload, const std::string &encryption_key = "") = 0;
 	virtual std::string DecodeTuyaMessage(unsigned char* buffer, const int size, const std::string &encryption_key = "") = 0;
 
-//	virtual unsigned long crc32(unsigned long crc, uint8_t const data[], uint32_t const len) { return 0;};
+	virtual int BuildSessionMessage(unsigned char *buffer) { m_session_established = true; return 0; }
+	virtual std::string DecodeSessionMessage(unsigned char* buffer, const int size) { return ""; }
 
+//	virtual unsigned long crc32(unsigned long crc, uint8_t const data[], uint32_t const len) { return 0;};
 
 protected:
 	Protocol m_protocol;
 	std::string m_device_key;
+	bool m_session_established;
 };
 
 #endif

--- a/src/tuyaAPI.hpp
+++ b/src/tuyaAPI.hpp
@@ -86,15 +86,19 @@ public:
 	// Get protocol version
 	Protocol getProtocol() const { return m_protocol; }
 
+	virtual void SetEncryptionKey(const std::string &key) { m_device_key = key; }
+	virtual bool NegotiateSession(const std::string &local_key) { SetEncryptionKey(local_key); return true; }
+
 	std::string GeneratePayload(const uint8_t command, const std::string &szDeviceID, const std::string &szDatapoints);
-	virtual int BuildTuyaMessage(unsigned char *buffer, const uint8_t command, const std::string &payload, const std::string &encryption_key) = 0;
-	virtual std::string DecodeTuyaMessage(unsigned char* buffer, const int size, const std::string &encryption_key) = 0;
+	virtual int BuildTuyaMessage(unsigned char *buffer, const uint8_t command, const std::string &payload, const std::string &encryption_key = "") = 0;
+	virtual std::string DecodeTuyaMessage(unsigned char* buffer, const int size, const std::string &encryption_key = "") = 0;
 
 //	virtual unsigned long crc32(unsigned long crc, uint8_t const data[], uint32_t const len) { return 0;};
 
 
 protected:
 	Protocol m_protocol;
+	std::string m_device_key;
 };
 
 #endif

--- a/src/tuyaAPI31.hpp
+++ b/src/tuyaAPI31.hpp
@@ -25,8 +25,8 @@ class tuyaAPI31 : public tuyaAPI
 public:
 	tuyaAPI31();
 
-	int BuildTuyaMessage(unsigned char *buffer, const uint8_t command, const std::string &payload, const std::string &encryption_key) override;
-	std::string DecodeTuyaMessage(unsigned char* buffer, const int size, const std::string &encryption_key) override;
+	int BuildTuyaMessage(unsigned char *buffer, const uint8_t command, const std::string &payload, const std::string &encryption_key = "") override;
+	std::string DecodeTuyaMessage(unsigned char* buffer, const int size, const std::string &encryption_key = "") override;
 
 private:
 	int encode_base64( const unsigned char *input_str, int input_size, unsigned char *output_str);

--- a/src/tuyaAPI33.cpp
+++ b/src/tuyaAPI33.cpp
@@ -35,6 +35,8 @@ tuyaAPI33::tuyaAPI33()
 
 int tuyaAPI33::BuildTuyaMessage(unsigned char *buffer, const uint8_t command, const std::string &szPayload, const std::string &encryption_key)
 {
+	const std::string &key = encryption_key.empty() ? m_device_key : encryption_key;
+
 	int bufferpos = 0;
 	memset(buffer, 0, PROTOCOL_33_HEADER_SIZE);
 	// set message prefix
@@ -72,7 +74,7 @@ int tuyaAPI33::BuildTuyaMessage(unsigned char *buffer, const uint8_t command, co
 	try
 	{
 		EVP_CIPHER_CTX* ctx = EVP_CIPHER_CTX_new();
-		EVP_EncryptInit_ex(ctx, EVP_aes_128_ecb(), nullptr, (unsigned char*)encryption_key.c_str(), nullptr);
+		EVP_EncryptInit_ex(ctx, EVP_aes_128_ecb(), nullptr, (unsigned char*)key.c_str(), nullptr);
 		EVP_EncryptUpdate(ctx, cEncryptedPayload, &encryptedChars, (unsigned char*)szPayload.c_str(), payloadSize);
 		encryptedSize = encryptedChars;
 		EVP_EncryptFinal_ex(ctx, cEncryptedPayload + encryptedChars, &encryptedChars);
@@ -128,6 +130,8 @@ int tuyaAPI33::BuildTuyaMessage(unsigned char *buffer, const uint8_t command, co
 
 std::string tuyaAPI33::DecodeTuyaMessage(unsigned char* buffer, const int size, const std::string &encryption_key)
 {
+	const std::string &key = encryption_key.empty() ? m_device_key : encryption_key;
+
 	std::string result;
 
 	int bufferpos = 0;
@@ -172,7 +176,7 @@ std::string tuyaAPI33::DecodeTuyaMessage(unsigned char* buffer, const int size, 
 			try
 			{
 				EVP_CIPHER_CTX* ctx = EVP_CIPHER_CTX_new();
-				EVP_DecryptInit_ex(ctx, EVP_aes_128_ecb(), nullptr, (unsigned char*)encryption_key.c_str(), nullptr);
+				EVP_DecryptInit_ex(ctx, EVP_aes_128_ecb(), nullptr, (unsigned char*)key.c_str(), nullptr);
 				EVP_DecryptUpdate(ctx, cDecryptedPayload, &decryptedChars, cEncryptedPayload, payloadSize);
 				decryptedSize = decryptedChars;
 				EVP_DecryptFinal_ex(ctx, cDecryptedPayload + decryptedSize, &decryptedChars);

--- a/src/tuyaAPI33.hpp
+++ b/src/tuyaAPI33.hpp
@@ -25,8 +25,8 @@ class tuyaAPI33 : public tuyaAPI
 public:
 	tuyaAPI33();
 
-	int BuildTuyaMessage(unsigned char *buffer, const uint8_t command, const std::string &payload, const std::string &encryption_key) override;
-	std::string DecodeTuyaMessage(unsigned char* buffer, const int size, const std::string &encryption_key) override;
+	int BuildTuyaMessage(unsigned char *buffer, const uint8_t command, const std::string &payload, const std::string &encryption_key = "") override;
+	std::string DecodeTuyaMessage(unsigned char* buffer, const int size, const std::string &encryption_key = "") override;
 
 private:
 	uint32_t m_seqno;

--- a/src/tuyaAPI34.hpp
+++ b/src/tuyaAPI34.hpp
@@ -31,19 +31,17 @@ public:
 	tuyaAPI34();
 
 	void SetEncryptionKey(const std::string &key) override;
-	bool NegotiateSession(const std::string &local_key) override;
 	int BuildTuyaMessage(unsigned char *buffer, const uint8_t command, const std::string &payload, const std::string &encryption_key = "") override;
 	std::string DecodeTuyaMessage(unsigned char* buffer, const int size, const std::string &encryption_key = "") override;
+
+	int BuildSessionMessage(unsigned char *buffer) override;
+	std::string DecodeSessionMessage(unsigned char* buffer, const int size) override;
 
 private:
 	unsigned char m_session_key[16];
 	unsigned char m_local_nonce[16];
 	unsigned char m_remote_nonce[16];
-	bool m_session_established;
 	uint32_t m_seqno;
-
-	int BuildSessionMessage(unsigned char *buffer, const uint8_t command, const std::string &payload);
-	std::string DecodeSessionMessage(unsigned char* buffer, const int size);
 
 };
 #endif // _tuyaAPI34

--- a/src/tuyaAPI34.hpp
+++ b/src/tuyaAPI34.hpp
@@ -30,10 +30,10 @@ public:
  ************************************************************************/
 	tuyaAPI34();
 
-	int BuildTuyaMessage(unsigned char *buffer, const uint8_t command, const std::string &payload, const std::string &encryption_key) override;
-	std::string DecodeTuyaMessage(unsigned char* buffer, const int size, const std::string &encryption_key) override;
-
-	bool ConnectToDevice(const std::string &hostname, const uint8_t retries = 5) override;
+	void SetEncryptionKey(const std::string &key) override;
+	bool NegotiateSession(const std::string &local_key) override;
+	int BuildTuyaMessage(unsigned char *buffer, const uint8_t command, const std::string &payload, const std::string &encryption_key = "") override;
+	std::string DecodeTuyaMessage(unsigned char* buffer, const int size, const std::string &encryption_key = "") override;
 
 private:
 	unsigned char m_session_key[16];
@@ -42,9 +42,8 @@ private:
 	bool m_session_established;
 	uint32_t m_seqno;
 
-	bool NegotiateSession(const std::string &local_key);
-	int BuildSessionMessage(unsigned char *buffer, const uint8_t command, const std::string &payload, const std::string &encryption_key);
-	std::string DecodeSessionMessage(unsigned char* buffer, const int size, const std::string &encryption_key);
+	int BuildSessionMessage(unsigned char *buffer, const uint8_t command, const std::string &payload);
+	std::string DecodeSessionMessage(unsigned char* buffer, const int size);
 
 };
 #endif // _tuyaAPI34

--- a/src/tuyaAPI34.hpp
+++ b/src/tuyaAPI34.hpp
@@ -43,6 +43,9 @@ private:
 	unsigned char m_remote_nonce[16];
 	uint32_t m_seqno;
 
+	int BuildMessage34(unsigned char *buffer, uint8_t command, const std::string &payload,
+	                   const unsigned char *key, int key_len);
+
 };
 #endif // _tuyaAPI34
 


### PR DESCRIPTION
- Promote NegotiateSession() to be a first-class citizen and public method of tuyaAPI.
- Remove the protocol-specific version of it which calls into the network send/receive functions.
- Let the protocol provide only BuildSessionMessage() and DecodeSessionMessage() calls, which a generic NegotiateSession can use.


This allows us to use the TuyaAPI protocol classes in environments like ESPHome where the socket handling needs to be done differently; you don't get to assume native BSD sockets. We can build a multi_kwh_meter example which doesn't use threads too, and just uses a poll() loop on its sockets. 