### PR TITLE
Fix HEARTBEAT payload offsets for 22-character device IDs

### DIFF
--- a/src/tuyaAPI.cpp
+++ b/src/tuyaAPI.cpp
@@ -69,8 +69,8 @@ std::string tuyaAPI::GeneratePayload(const uint8_t command, const std::string &s
 	{
 		case TUYA_HEART_BEAT:
 			szPayload = Tuya::Commands::HEART_BEAT;
-			szPayload.replace(28, 7, szDeviceID);
-			szPayload.replace(10, 7, szDeviceID);
+			szPayload.replace(27, 7, szDeviceID);
+			szPayload.replace(9,  7, szDeviceID);
 			break;
 		case TUYA_DP_QUERY:
 			szPayload = Tuya::Commands::DP_QUERY;


### PR DESCRIPTION
The hardcoded replace() offsets in the HEART_BEAT case are off by 1. The @devid@ placeholders start at positions 9 and 27 in the template {"gwId":"@devid@","devId":"@devid@"}, not 10 and 28.

For 7-character device IDs the bug is masked because the misalignment falls within the placeholder; for 22-character IDs (newer Tuya firmware) it produces malformed JSON that the device silently drops, indistinguishable from a wrong-key error.

The DP_QUERY case already uses the correct offset 9 for the same template position, confirming these are the intended values.